### PR TITLE
Support images with non-zero minimum bounds

### DIFF
--- a/color_extractor.go
+++ b/color_extractor.go
@@ -33,8 +33,8 @@ func ExtractColors(image image.Image) []color.Color {
 }
 
 func ExtractColorsWithConfig(image image.Image, config Config) []color.Color {
-	width := image.Bounds().Max.X
-	height := image.Bounds().Max.Y
+	width := image.Bounds().Dx()
+	height := image.Bounds().Dy()
 
 	// calculate downsizing ratio
 	stepX := int(math.Max(float64(width)/config.DownSizeTo, 1))
@@ -43,8 +43,8 @@ func ExtractColorsWithConfig(image image.Image, config Config) []color.Color {
 	// load image's pixels into buckets
 	var buckets [2][2][2]bucket
 	totalCount := 0.
-	for x := 0; x < width; x += stepX {
-		for y := 0; y < height; y += stepY {
+	for x := image.Bounds().Min.X; x < image.Bounds().Max.X; x += stepX {
+		for y := image.Bounds().Min.Y; y < image.Bounds().Max.Y; y += stepY {
 			color := image.At(x, y)
 			r, g, b, a := color.RGBA()
 			r >>= 8

--- a/color_extractor_test.go
+++ b/color_extractor_test.go
@@ -123,6 +123,13 @@ func TestExtractColors(t *testing.T) {
 				color.RGBA{R: 104, G: 152, B: 12, A: 255},
 			},
 		},
+		"Sub Image": {
+			Image: subImage(imageFromFile("example/Fotolia_45549559_320_480.jpg"), image.Rect(25, 120, 35, 130)),
+			ExtractedColors: []color.Color{
+				color.RGBA{R: 154, G: 1, B: 8, A: 255},
+				color.RGBA{R: 117, G: 2, B: 1, A: 255},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -156,6 +163,12 @@ func imageFromFile(filename string) image.Image {
 	}()
 	img, _, _ := image.Decode(file)
 	return img
+}
+
+func subImage(img image.Image, rect image.Rectangle) image.Image {
+	return img.(interface {
+		SubImage(r image.Rectangle) image.Image
+	}).SubImage(rect)
 }
 
 func testColorsEqual(a, b []color.Color) bool {


### PR DESCRIPTION
This is a neat project, thanks for your work on it!

I was trying to use this on images extracted with `SubImage` and found that it consistently returned {0 135 0}, looks like the code doesn't account for images with a minimum bound that's not zero. It's a very simple fix.